### PR TITLE
Tweaking ycdn rules

### DIFF
--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -162,7 +162,7 @@ YSLOW.registerRule({
             }
 
             // experimental custom header, waiting for specification
-            match = headers['X-CDN'] || headers['X-Cdn'] || headers['X-cdn'];
+            match = headers['X-CDN'] || headers['X-Cdn'] || headers['X-cdn'] || headers['X-Amz-Cf-Id'];
             if (match) {
                 continue;
             }

--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -107,7 +107,11 @@ YSLOW.registerRule({
             '^pimg.kr.yahoo.com',
             '^kr.img.n2o.yahoo.com',
             '^s3.amazonaws.com',
-            '^(www.)?google-analytics.com'
+            '^(www.)?google-analytics.com',
+            '.cloudfront.net',
+            '.ak.fbcdn.net',
+            'platform.twitter.com',
+            'apis.google.com'
         ],
         // array of regexps that will be treated as exception.
         exceptions: [

--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -108,10 +108,12 @@ YSLOW.registerRule({
             '^kr.img.n2o.yahoo.com',
             '^s3.amazonaws.com',
             '^(www.)?google-analytics.com',
-            '.cloudfront.net',
-            '.ak.fbcdn.net',
-            'platform.twitter.com',
-            'apis.google.com'
+            '.cloudfront.net', //Amazon CloudFront
+            '.ak.fbcdn.net', //Facebook images ebeded
+            'platform.twitter.com', //Twitter widget - Always via a CDN
+            'cdn.api.twitter.com', //Twitter API calls, served via Akamai
+            'apis.google.com', //Google's API Hosting
+            '.akamaihd.net' //Akamai - Facebook uses this for SSL assets
         ],
         // array of regexps that will be treated as exception.
         exceptions: [


### PR DESCRIPTION
Ive added some hostname matches which i think are widely used all over the internets.

Also matching the presence of header "X-Amz-Cf-Id" to confirm CDN usage. Thats something exclusively used by CloudFront.

One thing that can be considered is to match "sffe" in server header. It seems to be used by Google's static server, and all their static resources are self CDNed. This would then match the bulk of advertising related things currently reported by yslow as offender for ycdn rules.
