### PR TITLE
Fixed parsing of urls from url(...) tokens in CSS values

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -523,17 +523,16 @@ YSLOW.util = {
             return res;
         }
 
-        if (typeof res !== 'string' || res.indexOf('url(') !== 0) {
+        if (typeof res !== 'string') {
             return false;
         }
 
-        res = res.replace(/url\(/, '');
-        res = res.substr(0, res.lastIndexOf(')'));
-        if (res.indexOf('"') === 0) {
-            res = res.substr(1, res.length - 2);
+        var urlMatch = res.match(/\burl\((\'|\"|)([^\'\"]+?)\1\)/);
+        if (urlMatch) {
+            return urlMatch[2];
+        } else {
+            return false;
         }
-
-        return res;
     },
 
     /**


### PR DESCRIPTION
The `YSLOW.util.getComputedStyle` function produces the wrong result when a CSS value contains more than one end parenthesis after `url(` and `get_url` is set to `true`.

The bug is demonstrated by running this page through YSlow for Firefox or Chrome: http://gofish.dk/yslowbug/

Under the "Add Expires headers" rule in the "Grade" tab it says:

```
Grade C on Add Expires headers
There are 2 static components without a far-future expiration date.
(no expires) http://gofish.dk/favicon.ico
(no expires) http://gofish.dk/yslowbug/foo.png), -webkit-linear-gradient(top, rgb(0, 0, 0), rgb(255, 255, 255)
```
