### PR TITLE
Fix parsing of url values with quotes.

### DIFF
--- a/src/common/peeler.js
+++ b/src/common/peeler.js
@@ -307,7 +307,7 @@ YSLOW.peeler = {
      */
     findImportedStyleSheets: function (styleSheet, parentUrl) {
         var i, rules, rule, cssUrl, ff, len,
-            reFile = /url\s*\(["']*([^\)]+)["']*\)/i,
+            reFile = /url\s*\(["']*([^"'\)]+)["']*\)/i,
             comps = [];
 
         try {


### PR DESCRIPTION
`YSLOW.peeler.findImportedStyleSheets` returns components with URL values still containing ending quotes causing YQL request to fail.

Test case:
Use the _bookmarklet_ in Mozilla Firefox 10 (Mac OS X Lion) on https://developer.mozilla.org/
Run the test. Test fails because of URLs containing ending quotes for fonts.
