### PR TITLE
ycdn validation for CDN77

### DIFF
--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -167,7 +167,7 @@ YSLOW.registerRule({
             }
 
             // experimental custom header, use lowercase
-            match = headers['x-cdn'] || headers['x-amz-cf-id'];
+            match = headers['x-cdn'] || headers['x-amz-cf-id'] || headers['x-edge-location'];
             if (match) {
                 continue;
             }


### PR DESCRIPTION
Checks presence of "X-Edge-Location" response header and marks asset as CDN.

CDN77 adds this so i assume this check would have all onapp based CDNs covered.
