### PR TITLE
Avoid error with GNU tail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ phantomjs:
             $(SRC_COMMON)/renderers.js \
             $(SRC_COMMON)/peeler.js \
             $(SRC_COMMON)/peeler-bm-ch-ph.js; \
-        tail -r $(SRC_PHANTOMJS)/controller.js | sed '/YSLOW HERE/q' | tail -r ) | sed '/YSLOW HERE/d' \
+        tac $(SRC_PHANTOMJS)/controller.js | sed '/YSLOW HERE/q' | tac ) | sed '/YSLOW HERE/d' \
         > $(BUILD_PHANTOMJS)/yslow.js
 	@sed -i -e "s/{{YSLOW_VERSION}}/$(YSLOW_VERSION)/" $(BUILD_PHANTOMJS)/yslow.js
 	@echo "done"


### PR DESCRIPTION
I have following problem to build ySlow for PhantomJS.

```
$ make phantomjs
building PHANTOMJS...
tail: invalid option -- 'r'
Try `tail --help' for more information.
tail: invalid option -- 'r'
Try `tail --help' for more information.
done
```

```
$ uname -a
Linux www6292uf 2.6.32-40-server #87-Ubuntu SMP Tue Mar 6 02:10:02 UTC 2012 x86_64 GNU/Linux
```

```
$ tail --version
tail (GNU coreutils) 7.4
Copyright (C) 2009 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Paul Rubin, David MacKenzie, Ian Lance Taylor,
and Jim Meyering.
```

GNU `tail` don't accept `-r` option. It's should use `tac` instead of `tail` to avoid this issue.
