### PR TITLE
ChinaCache validation for ycdn

### DIFF
--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -167,7 +167,7 @@ YSLOW.registerRule({
             }
 
             // experimental custom header, use lowercase
-            match = headers['x-cdn'] || headers['x-amz-cf-id'] || headers['x-edge-location'];
+            match = headers['x-cdn'] || headers['x-amz-cf-id'] || headers['x-edge-location'] || headers['powered-by-chinacache'];
             if (match) {
                 continue;
             }


### PR DESCRIPTION
Chinacache adds response header in following format:-

Powered-By-ChinaCache: HIT from PTI-SP-1-3T1
