### PR TITLE
phantomjs: onError handling for uncaught js error of the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 pkg/
 *.swp
 .DS_Store
+node_modules/

--- a/src/phantomjs/controller.js
+++ b/src/phantomjs/controller.js
@@ -172,6 +172,9 @@ urls.forEach(function (url) {
             page.onConsoleMessage = function (msg) {
                 console.log(msg);
             };
+            page.onError = function (msg) {
+                console.error(msg);
+            };
         } else {
             page.onConsoleMessage = function (msg, line, source) {
                 console.log(JSON.stringify({
@@ -180,7 +183,17 @@ urls.forEach(function (url) {
                     source: source
                 }, null, 4));
             };
+            page.onError = function (msg, trace) {
+                console.error(JSON.stringify({
+                    message: msg,
+                    stacktrace: trace
+                }));
+            };
         }
+    } else {
+        page.onError = function () {
+            // catch uncaught error from the page
+        };
     }
 
     // set user agent string


### PR DESCRIPTION
There was no way to prevent javascript error that are thrown on the page from being passed through:

```
$ phantomjs build/phantomjs/yslow.js --info basic http://jsbin.com/ubibep/1
TypeError: 'undefined' is not a function (evaluating '"foo".unknownMethod()')

  http://jsbin.com/ubibep/1:18
{"w":53561,"o":89,"u":"http%3A%2F%2Fjsbin.com%2Fubibep%2F1","r":8,"i":"ydefault","lt":1210}
```

I've implemented the onError callback and made it work similar to the onConsoleMessage implementation. So by default (`--console 0`) all errors are ignored:

```
$ phantomjs build/phantomjs/yslow.js --info basic http://jsbin.com/ubibep/1            
{"w":53561,"o":89, ...}
```

But the user has the option to output the errors with `--console 1` or `--console 2`:

```
$ phantomjs build/phantomjs/yslow.js --info basic --console 1 http://jsbin.com/ubibep/1
TypeError: 'undefined' is not a function (evaluating '"foo".unknownMethod()')
{"w":53561,"o":89, ...}
```

```
$ phantomjs build/phantomjs/yslow.js --info basic --console 2 http://jsbin.com/ubibep/1
{"message":"TypeError: 'undefined' is not a function (evaluating '\"foo\".unknownMethod()')","stacktrace":[{"file":"http://jsbin.com/ubibep/1","line":18,"function":""}]}
{"w":53561,"o":89, ... }
```

I've thought about adding a separate `error` option, but I think using the `console` option is sufficient. What do you think?

\ naltatis 
