### PR TITLE
Location header fix; add YSlow version to beacon; valid protocols check

### DIFF
--- a/src/common/component.js
+++ b/src/common/component.js
@@ -92,7 +92,7 @@ YSLOW.Component.prototype.populateProperties = function (resolveRedirect, ignore
 
     // check location
     // bookmarklet and har already handle redirects
-    if (that.headers.location && resolveRedirect) {
+    if (that.headers.location && resolveRedirect && that.headers.location !== that.url) {
         // Add a new component.
         comp = that.parent.addComponentNoDuplicate(that.headers.location,
             (that.type !== 'redirect' ? that.type : 'unknown'), that.url);

--- a/src/common/componentSet.js
+++ b/src/common/componentSet.js
@@ -498,10 +498,9 @@ YSLOW.ComponentSet.prototype = {
 };
 
 /*
- * List of protocols to ignore in component set.
+ * List of valid protocols in component sets.
  */
-YSLOW.ComponentSet.ignoreProtocols = ['data', 'chrome', 'javascript', 'about',
-    'resource', 'jar', 'chrome-extension', 'file'];
+YSLOW.ComponentSet.validProtocols = ['http', 'https', 'ftp'];
 
 /**
  * @private
@@ -511,21 +510,21 @@ YSLOW.ComponentSet.ignoreProtocols = ['data', 'chrome', 'javascript', 'about',
  */
 YSLOW.ComponentSet.isValidProtocol = function (s) {
     var i, index, protocol,
-        ignoreProtocols = this.ignoreProtocols,
-        len = ignoreProtocols.length;
+        validProtocols = this.validProtocols,
+        len = validProtocols.length;
 
     s = s.toLowerCase();
     index = s.indexOf(':');
     if (index > 0) {
         protocol = s.substr(0, index);
         for (i = 0; i < len; i += 1) {
-            if (protocol === ignoreProtocols[i]) {
-                return false;
+            if (protocol === validProtocols[i]) {
+                return true;
             }
         }
     }
 
-    return true;
+    return false;
 };
 
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -836,6 +836,7 @@ YSLOW.util = {
             }
         }
 
+        params.v = YSLOW.version;
         params.w = parseInt(yscontext.PAGE.totalSize, 10);
         params.o = parseInt(yscontext.PAGE.overallScore, 10);
         params.u = encodeURIComponent(yscontext.result_set.url);


### PR DESCRIPTION
A couple patches that we've integrated into our YSlow code for GTmetrix:

**Location header fix**

Some sites have a Location header that points to itself.  Firefox is smart enough to not follow the redirect, but YSlow doesn't handle it properly.

**Add YSlow version to beacon**

I don't think YSlow rules have changed much in a while, but I think it's important to save the YSlow version with the beacon data.  It adds the version in as the 'v' parameter.

**Valid protocols check**

I'm not 100% on this one, but it's worked for us.  YSlow gets stuck when there are resources on the page which use certain protocols (eg. file://, mms://).  I've switched YSLOW.ComponentSet.isValidProtocol() to check against a small list of protocols that Firefox will work with (http, https, ftp).  Not sure if other protocols should be added to the list or not.
