### PR TITLE
isETagGood IIS7+ compatible

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -394,7 +394,7 @@ YSLOW.util = {
      * @return {Boolean} TRUE if ETag is good, FALSE otherwise
      */
     isETagGood: function (etag) {
-        var reIIS = /^[0-9a-f]+:[0-9a-f]+$/,
+        var reIIS = /^[0-9a-f]+:([1-9a-f]|[0-9a-f]{2,})$/,
             reApache = /^[0-9a-f]+\-[0-9a-f]+\-[0-9a-f]+$/;
 
         if (!etag) {


### PR DESCRIPTION
https://github.com/marcelduran/yslow/issues/61

http://technet.microsoft.com/en-us/library/ee619764(v=WS.10).aspx
"In IIS 7.0, the metabase change number of 0 is the default setting and cannot be modified."

This will make the default IIS 7.0+ ETAG CDNs compatible as Timestamp:0 can be used across multiple IIS CDNs.

```
- var reIIS = /^[0-9a-f]+:[0-9a-f]+$/,
+ var reIIS = /^[0-9a-f]+:([1-9a-f]|[0-9a-f]{2,})$/,
```
