### PR TITLE
always use max-age if exists following 1.1 spec

### DIFF
--- a/src/common/component.js
+++ b/src/common/component.js
@@ -141,15 +141,13 @@ YSLOW.Component.prototype.populateProperties = function (resolveRedirect, ignore
     that.uncompressed_size = that.body.length;
 
     // expiration based on either Expires or Cache-Control headers
-    expires = that.headers.expires;
-    if (expires && expires.length > 0) {
-        // set expires as a JS object
-        that.expires = new Date(expires);
-        if (that.expires.toString() === 'Invalid Date') {
-            that.expires = that.getMaxAge();
-        }
-    } else {
+    // always use max-age if exists following 1.1 spec
+    // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3                                                                                      
+    if (that.getMaxAge() !== undefined) {
         that.expires = that.getMaxAge();
+    }
+    else if (that.headers.expires && that.headers.expires.length > 0) {
+        that.expires = new Date(that.headers.expires);
     }
 
     // compare image original dimensions with actual dimensions, data uri is


### PR DESCRIPTION
Fetching the cache header is done in wrong order right? If both expires and max-age exists, expires is chosen but should be max-age according to the 1.1 spec http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.3 

This is happens when different timings is set, check https://developers.google.com/ and the https://developers.google.com/_static/css/screen.css for example:

<pre>
cache-control:public, max-age=600, public, max-age=600
date:Mon, 20 May 2013 09:02:23 GMT
expires:Fri, 17 May 2013 03:08:07 GMT
</pre>
