### PR TITLE
Add the type attribute to a failed node, fix #92

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -1525,11 +1525,12 @@ YSLOW.util = {
                 if (res.score < 0) {
                     skipped += 1;
                     cases.push('      <skipped>score N/A</skipped>');
+                    line = '      <failure type="skipped"';
                 } else {
                   failures += 1;
+                  line = '      <failure type="failed"';
                 }
 
-                line = '      <failure';
                 if (res.message) {
                     line += ' message="' + safeAttr(res.message) + '"';
                 }


### PR DESCRIPTION
This fixes the issue reported in #92 by adding the `type` attribute to the `<failed>` node.

fix #92
