### PR TITLE
Fixes to make it compatible with phantomjs 2.0.0

### DIFF
--- a/src/phantomjs/controller.js
+++ b/src/phantomjs/controller.js
@@ -18,7 +18,8 @@
 // parse args
 var i, arg, page, urlCount, viewport,
     webpage = require('webpage'),
-    args = phantom.args,
+    system = require('system'),
+    args = system.args,
     len = args.length,
     urls = [],
     yslowArgs = {
@@ -56,7 +57,7 @@ var i, arg, page, urlCount, viewport,
     };
 
 // loop args
-for (i = 0; i < len; i += 1) {
+for (i = 1; i < len; i += 1) {
     arg = args[i];
     if (arg[0] !== '-') {
         // url, normalize if needed
@@ -94,7 +95,7 @@ if (unaryArgs.version) {
 if (len === 0 || urlCount === 0 || unaryArgs.help) {
     console.log([
         '',
-        '  Usage: phantomjs [phantomjs options] ' + phantom.scriptName + ' [yslow options] [url ...]',
+        '  Usage: phantomjs [phantomjs options] ' + args[0] + ' [yslow options] [url ...]',
         '',
         '  PhantomJS Options:',
         '',
@@ -120,13 +121,13 @@ if (len === 0 || urlCount === 0 || unaryArgs.help) {
         '',
         '  Examples:',
         '',
-        '    phantomjs ' + phantom.scriptName + ' http://yslow.org',
-        '    phantomjs ' + phantom.scriptName + ' -i grade -f xml www.yahoo.com www.cnn.com www.nytimes.com',
-        '    phantomjs ' + phantom.scriptName + ' --info all --format plain --ua "MSIE 9.0" http://yslow.org',
-        '    phantomjs ' + phantom.scriptName + ' -i basic --rulseset yslow1 -d http://yslow.org',
-        '    phantomjs ' + phantom.scriptName + ' -i grade -b http://www.showslow.com/beacon/yslow/ -v yslow.org',
-        '    phantomjs --load-plugins=yes ' + phantom.scriptName + ' -vp 800x600 http://www.yahoo.com',
-        '    phantomjs ' + phantom.scriptName + ' -i grade -f tap -t 85 http://yslow.org',
+        '    phantomjs ' + args[0] + ' http://yslow.org',
+        '    phantomjs ' + args[0] + ' -i grade -f xml www.yahoo.com www.cnn.com www.nytimes.com',
+        '    phantomjs ' + args[0] + ' --info all --format plain --ua "MSIE 9.0" http://yslow.org',
+        '    phantomjs ' + args[0] + ' -i basic --rulseset yslow1 -d http://yslow.org',
+        '    phantomjs ' + args[0] + ' -i grade -b http://www.showslow.com/beacon/yslow/ -v yslow.org',
+        '    phantomjs --load-plugins=yes ' + args[0] + ' -vp 800x600 http://www.yahoo.com',
+        '    phantomjs ' + args[0] + ' -i grade -f tap -t 85 http://yslow.org',
         ''
     ].join('\n'));
     phantom.exit();


### PR DESCRIPTION
phantom.args deprecated in favor of system.args
phantom.scriptName deprecated in favor of system.args[0]
