### PR TITLE
[Bugfix] fix jsdom bug in node and nodeserver package

### DIFF
--- a/src/nodejs/controller.js
+++ b/src/nodejs/controller.js
@@ -4,6 +4,8 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 
+var jsdom = require('jsdom');
+const { JSDOM } = jsdom;
 var files, dict,
     prefix = '',
     harContent = '',
@@ -12,7 +14,8 @@ var files, dict,
     http = require('http'),
     url = require('url'),
     YSLOW = require('yslow').YSLOW,
-    doc = require('jsdom').jsdom(),
+    dom = new JSDOM(),
+    doc = dom.window.document,
     program = require('commander'),
     util = YSLOW.util,
 

--- a/src/nodeserver/server.js
+++ b/src/nodeserver/server.js
@@ -6,9 +6,12 @@
 
 'use strict';
 
+var jsdom = require('jsdom');
+const { JSDOM } = jsdom;
 var express = require('express'),
     YSLOW = require('yslow').YSLOW,
-    doc = require('jsdom').jsdom(),
+    dom = new JSDOM(),
+    doc = dom.window.document,
     http = require('http'),
     url = require('url'),
     fs = require('fs'),


### PR DESCRIPTION
Hi, 

I'm trying to use the node version of yslow, but I'm running into some trouble regarding jsdom. I suppose there are newer versions, matching the `"jsdom": ">=0.2.10"`dependency, that are not quite compatible.

I'm currently getting version 12.2.0 which raises the error: `TypeError: require(...).jsdom is not a function`. This error can be fixed with this PR, can you check if this is the desired solution ?