### PR TITLE
Recognize GoCache CDN 

### DIFF
--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -130,6 +130,7 @@ YSLOW.registerRule({
         // array of regexps that match CDN Server HTTP headers
         servers: [
             'cloudflare-nginx' // not using ^ and $ due to invisible
+            '^gocache'
         ],
         // which component types should be on CDN
         types: ['js', 'css', 'image', 'cssimage', 'flash', 'favicon']

--- a/src/common/rules.js
+++ b/src/common/rules.js
@@ -129,7 +129,7 @@ YSLOW.registerRule({
         ],
         // array of regexps that match CDN Server HTTP headers
         servers: [
-            'cloudflare-nginx' // not using ^ and $ due to invisible
+            'cloudflare-nginx', // not using ^ and $ due to invisible
             '^gocache'
         ],
         // which component types should be on CDN


### PR DESCRIPTION
[GoCache](https://www.gocache.com.br/en/what-is-a-cdn/) is a South American CDN. Yslow currently does not report resources in GoCache as using a CDN.
This pull request add GoCache detection to yslow based on the Server header (GoCache provide DNS servers and some user domains/subdomains won't be CNAME entries).